### PR TITLE
fix: render list end event date

### DIFF
--- a/src/screens/carrousel/container.ts
+++ b/src/screens/carrousel/container.ts
@@ -48,7 +48,7 @@ export function useChannelScreenContainer() {
 		const availableEvents: IAgenda[] = []
 
 		for (const event of agenda) {
-			const isEnded = isAfter(new Date(), parseISO(event.endsAt))
+			const isEnded = isAfter(new Date(), parseISO(event.beginsAt))
 
 			if (isEnded) continue
 


### PR DESCRIPTION
This pull request includes a minor change to the `useChannelScreenContainer` function in the `src/screens/carrousel/container.ts` file. The change modifies the logic to determine if an event has ended by comparing the current date with the event's `beginsAt` date instead of its `endsAt` date.

* [`src/screens/carrousel/container.ts`](diffhunk://#diff-b838c1f845ad30915ed12068ea5352c6460fd67deb33dc12cf8914e7885ce89bL51-R51): Updated the `isEnded` condition to use `beginsAt` instead of `endsAt` in the `useChannelScreenContainer` function.